### PR TITLE
Repair code example in storageClass description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: ssd-local-path
-provisioner: cluster.local/local-path-provisioner
+provisioner: rancher.io/local-path
 parameters:
   nodePath: /data/ssd
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
I copied this example and had a really rough go as a kubernetes beginner; I needed a custom storageClass for the RabbitMQ operator.

So my pods were broken for a long while, until I changed my storageClass to match the other `local-path` storageClass already enabled in my cluster. This `rancher.io/local-path` provisioner seems to be the key to an easy deployment of custom storageClasses.